### PR TITLE
Add FCM v1 API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ Dependencies
 - For WebPush (WP), pywebpush 1.3.0+ is required (optional). py-vapid 1.3.0+ is required for generating the WebPush private key; however this
   step does not need to occur on the application server.
 - For Apple Push (APNS), apns2 0.3+ is required (optional).
+- For FCM, firebase-admin 5+ is required (optional).
 
 Setup
 -----
@@ -44,7 +45,7 @@ You can install the library directly from pypi using pip:
 
 .. code-block:: shell
 
-	$ pip install django-push-notifications[WP,APNS]
+	$ pip install django-push-notifications[WP,APNS,FCM]
 
 
 Edit your settings.py file:
@@ -56,9 +57,13 @@ Edit your settings.py file:
 		"push_notifications"
 	)
 
+	# Import the firebase service
+	from firebase_admin import auth
+
+	# Initialize the default app (either use `GOOGLE_APPLICATION_CREDENTIALS` environment variable, or pass a firebase_admin.credentials.Certificate instance)
+	default_app = firebase_admin.initialize_app()
+
 	PUSH_NOTIFICATIONS_SETTINGS = {
-		"FCM_API_KEY": "[your api key]",
-		"GCM_API_KEY": "[your api key]",
 		"APNS_CERTIFICATE": "/path/to/your/certificate.pem",
 		"APNS_TOPIC": "com.example.push_test",
 		"WNS_PACKAGE_SECURITY_ID": "[your package security id, e.g: 'ms-app://e-3-4-6234...']",
@@ -68,7 +73,10 @@ Edit your settings.py file:
 	}
 
 .. note::
-    If you need to support multiple mobile applications from a single Django application, see `Multiple Application Support <https://github.com/jazzband/django-push-notifications/wiki/Multiple-Application-Support>`_ for details.
+	To migrate from legacy FCM APIs to HTTP v1, see `docs/FCM <https://github.com/jazzband/django-push-notifications/blob/master/docs/FCM.rst>`_.
+
+.. note::
+	If you need to support multiple mobile applications from a single Django application, see `Multiple Application Support <https://github.com/jazzband/django-push-notifications/wiki/Multiple-Application-Support>`_ for details.
 
 .. note::
 	If you are planning on running your project with ``APNS_USE_SANDBOX=True``, then make sure you have set the
@@ -87,7 +95,6 @@ Settings list
 -------------
 All settings are contained in a ``PUSH_NOTIFICATIONS_SETTINGS`` dict.
 
-In order to use FCM/GCM, you are required to include ``FCM_API_KEY`` or ``GCM_API_KEY``.
 For APNS, you are required to include ``APNS_CERTIFICATE``.
 For WNS, you need both the ``WNS_PACKAGE_SECURITY_KEY`` and the ``WNS_SECRET_KEY``.
 
@@ -109,11 +116,8 @@ For WNS, you need both the ``WNS_PACKAGE_SECURITY_KEY`` and the ``WNS_SECRET_KEY
 
 **FCM/GCM settings**
 
-- ``FCM_API_KEY``: Your API key for Firebase Cloud Messaging.
-- ``FCM_POST_URL``: The full url that FCM notifications will be POSTed to. Defaults to https://fcm.googleapis.com/fcm/send.
+- ``FIREBASE_APP``: Firebase app instance that is used to send the push notification. If not provided, the app will be using the default app instance that you've instantiated with ``firebase_admin.initialize_app()``.
 - ``FCM_MAX_RECIPIENTS``: The maximum amount of recipients that can be contained per bulk message. If the ``registration_ids`` list is larger than that number, multiple bulk messages will be sent. Defaults to 1000 (the maximum amount supported by FCM).
-- ``FCM_ERROR_TIMEOUT``: The timeout on FCM POSTs.
-- ``GCM_API_KEY``, ``GCM_POST_URL``, ``GCM_MAX_RECIPIENTS``, ``GCM_ERROR_TIMEOUT``: Same parameters for GCM
 
 **WNS settings**
 
@@ -147,6 +151,15 @@ FCM/GCM and APNS services have slightly different semantics. The app tries to of
 	# but for more complex nested collections the extras dict will be sent via
 	# the bulk message api.
 	device.send_message(None, extra={"foo": "bar"})
+	# You may also pass a Firebase message object.
+	device.send_message(messaging.Message(
+		notification=messaging.Notification(
+			title='Hello World',
+			body='What a beautiful day.'
+		),
+	))
+	# If you want to use gcm.send_message directly, you will have to use messaging.Message.
+
 
 	device = APNSDevice.objects.get(registration_id=apns_token)
 	device.send_message("You've got mail") # Alert message may only be sent as text.
@@ -215,19 +228,17 @@ value per user. Assuming User model has a method get_badge returning badge count
 		badge=lambda token: APNSDevice.objects.get(registration_id=token).user.get_badge()
 	)
 
-Firebase vs Google Cloud Messaging
+Firebase
 ----------------------------------
 
-``django-push-notifications`` supports both Google Cloud Messaging and Firebase Cloud Messaging (which is now the officially supported messaging platform from Google). When registering a device, you must pass the ``cloud_message_type`` parameter to set the cloud type that matches the device needs.
-This is currently defaulting to ``'GCM'``, but may change to ``'FCM'`` at some point. You are encouraged to use the `officially supported library <https://developers.google.com/cloud-messaging/faq>`_.
+``django-push-notifications`` supports Firebase Cloud Messaging v1.
 
 When using FCM, ``django-push-notifications`` will automatically use the `notification and data messages format <https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages>`_ to be conveniently handled by Firebase devices. You may want to check the payload to see if it matches your needs, and review your notification statuses in `FCM Diagnostic console <https://support.google.com/googleplay/android-developer/answer/2663268?hl=en>`_.
-
 
 .. code-block:: python
 
 	# Create a FCM device
-	fcm_device = GCMDevice.objects.create(registration_id="token", cloud_message_type="FCM", user=the_user)
+	fcm_device = GCMDevice.objects.create(registration_id="token", user=the_user)
 
 	# Send a notification message
 	fcm_device.send_message("This is a message")
@@ -247,14 +258,10 @@ When using FCM, ``django-push-notifications`` will automatically use the `notifi
 	# Send a data message only
 	fcm_device.send_message(None, extra={"other": "content", "misc": "data"})
 
-You can disable this default behaviour by setting ``use_fcm_notifications`` to ``False``.
 
-.. code-block:: python
 
-	fcm_device = GCMDevice.objects.create(registration_id="token", cloud_message_type="FCM", user=the_user)
-
-	# Send a data message with classic format
-	fcm_device.send_message("This is a message", use_fcm_notifications=False)
+Behind the scenes, a `Firebase Message <https://firebase.google.com/docs/reference/admin/dotnet/class/firebase-admin/messaging/message>`_ will be created.
+You can also create this yourself and pass it to the ``send_message`` method instead.
 
 
 Sending FCM/GCM messages to topic members
@@ -264,10 +271,12 @@ Note: gcm_send_bulk_message must be used when sending messages to topic subscrib
 
 .. code-block:: python
 
-	from push_notifications.gcm import send_message
+	from push_notifications.gcm import send_message, dict_to_fcm_message
 
-        # First param is "None" because no Registration_id is needed, the message will be sent to all devices subscribed to the topic.
-        send_message(None, {"body": "Hello members of my_topic!"}, cloud_type="FCM", to="/topics/my_topic")
+	# Create message object from dictonary. You can also directly create a messaging.Message object.
+	message = dict_to_fcm_message({"body": "Hello members of my_topic!"})
+	# First param is "None" because no Registration_id is needed, the message will be sent to all devices subscribed to the topic.
+	send_message(None, message, to="/topics/my_topic")
 
 Reference: `FCM Documentation <https://firebase.google.com/docs/cloud-messaging/android/topic-messaging>`_
 
@@ -275,7 +284,6 @@ Exceptions
 ----------
 
 - ``NotificationError(Exception)``: Base exception for all notification-related errors.
-- ``gcm.GCMError(NotificationError)``: An error was returned by GCM. This is never raised when using bulk notifications.
 - ``apns.APNSError(NotificationError)``: Something went wrong upon sending APNS notifications.
 - ``apns.APNSDataOverflow(APNSError)``: The APNS payload exceeds its maximum size and cannot be sent.
 

--- a/docs/FCM.rst
+++ b/docs/FCM.rst
@@ -1,0 +1,112 @@
+Generate service account private key file
+------------------------------
+
+Migrating to FCM v1 API
+------------------------------
+
+- GCM and legacy FCM API support have been removed. (GCM is off since 2019, FCM legacy will be turned off in june 2024)
+- Firebase-Admin SDK has been added
+
+
+Authentication does not work with an access token anymore.
+Follow the `official docs <https://firebase.google.com/docs/admin/setup/#initialize_the_sdk_in_non-google_environments>`_ to generate a service account private key file.
+
+Then, either define an environment variable ``GOOGLE_APPLICATION_CREDENTIALS`` with the path to the service account private key file, or pass the path to the file explicitly when initializing the SDK.
+
+Initialize the firebase admin in your ``settings.py`` file.
+
+.. code-block:: python
+
+	# Import the firebase service
+	from firebase_admin import auth
+
+	# Initialize the default app
+	default_app = firebase_admin.initialize_app()
+
+
+This will do the trick.
+
+
+Multiple Application Support
+------------------------------
+
+Removed settings:
+
+- ``API_KEY``
+- ``POST_URL``
+- ``ERROR_TIMEOUT``
+
+Added setting:
+
+- ``FIREBASE_APP``: initialise your firebase app and set it here.
+
+
+.. code-block:: python
+
+	# Before
+	PUSH_NOTIFICATIONS_SETTINGS = {
+		# Load and process all PUSH_NOTIFICATIONS_SETTINGS using the AppConfig manager.
+		"CONFIG": "push_notifications.conf.AppConfig",
+
+		# collection of all defined applications
+		"APPLICATIONS": {
+			"my_fcm_app": {
+				# PLATFORM (required) determines what additional settings are required.
+				"PLATFORM": "FCM",
+
+				# required FCM setting
+				"API_KEY": "[your api key]",
+			},
+			"my_ios_app": {
+				  # PLATFORM (required) determines what additional settings are required.
+				  "PLATFORM": "APNS",
+
+				  # required APNS setting
+				  "CERTIFICATE": "/path/to/your/certificate.pem",
+			},
+			"my_wns_app": {
+				# PLATFORM (required) determines what additional settings are required.
+				"PLATFORM": "WNS",
+
+				# required WNS settings
+				"PACKAGE_SECURITY_ID": "[your package security id, e.g: 'ms-app://e-3-4-6234...']",
+				"SECRET_KEY": "[your app secret key, e.g.: 'KDiejnLKDUWodsjmewuSZkk']",
+			},
+		}
+	}
+
+	# After
+
+	firebase_app = firebase_admin.initialize_app()
+
+	PUSH_NOTIFICATIONS_SETTINGS = {
+		# Load and process all PUSH_NOTIFICATIONS_SETTINGS using the AppConfig manager.
+		"CONFIG": "push_notifications.conf.AppConfig",
+
+		# collection of all defined applications
+		"APPLICATIONS": {
+			"my_fcm_app": {
+				# PLATFORM (required) determines what additional settings are required.
+				"PLATFORM": "FCM",
+
+				# FCM settings
+				"FIREBASE_APP": firebase_app,
+			},
+			"my_ios_app": {
+				  # PLATFORM (required) determines what additional settings are required.
+				  "PLATFORM": "APNS",
+
+				  # required APNS setting
+				  "CERTIFICATE": "/path/to/your/certificate.pem",
+			},
+			"my_wns_app": {
+				# PLATFORM (required) determines what additional settings are required.
+				"PLATFORM": "WNS",
+
+				# required WNS settings
+				"PACKAGE_SECURITY_ID": "[your package security id, e.g: 'ms-app://e-3-4-6234...']",
+				"SECRET_KEY": "[your app secret key, e.g.: 'KDiejnLKDUWodsjmewuSZkk']",
+			},
+		}
+	}
+

--- a/push_notifications/conf/__init__.py
+++ b/push_notifications/conf/__init__.py
@@ -1,9 +1,9 @@
 from django.utils.module_loading import import_string
 
+from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS  # noqa: I001
 from .app import AppConfig  # noqa: F401
 from .appmodel import AppModelConfig  # noqa: F401
 from .legacy import LegacyConfig  # noqa: F401
-from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS  # noqa: I001
 
 
 manager = None

--- a/push_notifications/conf/app.py
+++ b/push_notifications/conf/app.py
@@ -25,7 +25,6 @@ MISSING_SETTING = (
 PLATFORMS = [
 	"APNS",
 	"FCM",
-	"GCM",
 	"WNS",
 	"WP",
 ]
@@ -55,9 +54,9 @@ APNS_OPTIONAL_SETTINGS = [
 	"USE_SANDBOX", "USE_ALTERNATIVE_PORT", "TOPIC"
 ]
 
-FCM_REQUIRED_SETTINGS = GCM_REQUIRED_SETTINGS = ["API_KEY"]
-FCM_OPTIONAL_SETTINGS = GCM_OPTIONAL_SETTINGS = [
-	"POST_URL", "MAX_RECIPIENTS", "ERROR_TIMEOUT"
+FCM_REQUIRED_SETTINGS = []
+FCM_OPTIONAL_SETTINGS = [
+	"MAX_RECIPIENTS", "FIREBASE_APP"
 ]
 
 WNS_REQUIRED_SETTINGS = ["PACKAGE_SECURITY_ID", "SECRET_KEY"]
@@ -189,23 +188,8 @@ class AppConfig(BaseConfig):
 			application_id, application_config, FCM_REQUIRED_SETTINGS
 		)
 
-		application_config.setdefault("POST_URL", "https://fcm.googleapis.com/fcm/send")
+		application_config.setdefault("FIREBASE_APP", None)
 		application_config.setdefault("MAX_RECIPIENTS", 1000)
-		application_config.setdefault("ERROR_TIMEOUT", None)
-
-	def _validate_gcm_config(self, application_id, application_config):
-		allowed = (
-			REQUIRED_SETTINGS + OPTIONAL_SETTINGS + GCM_REQUIRED_SETTINGS + GCM_OPTIONAL_SETTINGS
-		)
-
-		self._validate_allowed_settings(application_id, application_config, allowed)
-		self._validate_required_settings(
-			application_id, application_config, GCM_REQUIRED_SETTINGS
-		)
-
-		application_config.setdefault("POST_URL", "https://android.googleapis.com/gcm/send")
-		application_config.setdefault("MAX_RECIPIENTS", 1000)
-		application_config.setdefault("ERROR_TIMEOUT", None)
 
 	def _validate_wns_config(self, application_id, application_config):
 		allowed = (
@@ -303,23 +287,14 @@ class AppConfig(BaseConfig):
 
 		return app_config.get(settings_key)
 
+	def get_firebase_app(self, application_id=None):
+		return self._get_application_settings(application_id, "FCM", "FIREBASE_APP")
+
 	def has_auth_token_creds(self, application_id=None):
 		return self.has_token_creds
 
-	def get_gcm_api_key(self, application_id=None):
-		return self._get_application_settings(application_id, "GCM", "API_KEY")
-
-	def get_fcm_api_key(self, application_id=None):
-		return self._get_application_settings(application_id, "FCM", "API_KEY")
-
-	def get_post_url(self, cloud_type, application_id=None):
-		return self._get_application_settings(application_id, cloud_type, "POST_URL")
-
-	def get_error_timeout(self, cloud_type, application_id=None):
-		return self._get_application_settings(application_id, cloud_type, "ERROR_TIMEOUT")
-
-	def get_max_recipients(self, cloud_type, application_id=None):
-		return self._get_application_settings(application_id, cloud_type, "MAX_RECIPIENTS")
+	def get_max_recipients(self, application_id=None):
+		return self._get_application_settings(application_id, "FCM", "MAX_RECIPIENTS")
 
 	def get_apns_certificate(self, application_id=None):
 		r = self._get_application_settings(application_id, "APNS", "CERTIFICATE")

--- a/push_notifications/conf/base.py
+++ b/push_notifications/conf/base.py
@@ -2,6 +2,10 @@ from django.core.exceptions import ImproperlyConfigured
 
 
 class BaseConfig:
+
+	def get_firebase_app(self, application_id=None):
+		raise NotImplementedError
+
 	def has_auth_token_creds(self, application_id=None):
 		raise NotImplementedError
 
@@ -17,25 +21,13 @@ class BaseConfig:
 	def get_apns_use_alternative_port(self, application_id=None):
 		raise NotImplementedError
 
-	def get_fcm_api_key(self, application_id=None):
-		raise NotImplementedError
-
-	def get_gcm_api_key(self, application_id=None):
-		raise NotImplementedError
-
 	def get_wns_package_security_id(self, application_id=None):
 		raise NotImplementedError
 
 	def get_wns_secret_key(self, application_id=None):
 		raise NotImplementedError
 
-	def get_post_url(self, cloud_type, application_id=None):
-		raise NotImplementedError
-
-	def get_error_timeout(self, cloud_type, application_id=None):
-		raise NotImplementedError
-
-	def get_max_recipients(self, cloud_type, application_id=None):
+	def get_max_recipients(self, application_id=None):
 		raise NotImplementedError
 
 	def get_applications(self):

--- a/push_notifications/conf/legacy.py
+++ b/push_notifications/conf/legacy.py
@@ -14,7 +14,6 @@ class empty:
 
 
 class LegacyConfig(BaseConfig):
-
 	msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
 
 	def _get_application_settings(self, application_id, settings_key, error_message):
@@ -32,42 +31,17 @@ class LegacyConfig(BaseConfig):
 			)
 			raise ImproperlyConfigured(msg)
 
-	def get_gcm_api_key(self, application_id=None):
+	def get_firebase_app(self, application_id=None):
+		key = "FIREBASE_APP"
 		msg = (
-			'Set PUSH_NOTIFICATIONS_SETTINGS["GCM_API_KEY"] to send messages through GCM.'
-		)
-		return self._get_application_settings(application_id, "GCM_API_KEY", msg)
-
-	def get_fcm_api_key(self, application_id=None):
-		msg = (
-			'Set PUSH_NOTIFICATIONS_SETTINGS["FCM_API_KEY"] to send messages through FCM.'
-		)
-		return self._get_application_settings(application_id, "FCM_API_KEY", msg)
-
-	def get_post_url(self, cloud_type, application_id=None):
-		key = "{}_POST_URL".format(cloud_type)
-		msg = (
-			'Set PUSH_NOTIFICATIONS_SETTINGS["{}"] to send messages through {}.'.format(
-				key, cloud_type
-			)
+			'Set PUSH_NOTIFICATIONS_SETTINGS["{}"] to send messages through FCM.'.format(key)
 		)
 		return self._get_application_settings(application_id, key, msg)
 
-	def get_error_timeout(self, cloud_type, application_id=None):
-		key = "{}_ERROR_TIMEOUT".format(cloud_type)
+	def get_max_recipients(self, application_id=None):
+		key = "FCM_MAX_RECIPIENTS"
 		msg = (
-			'Set PUSH_NOTIFICATIONS_SETTINGS["{}"] to send messages through {}.'.format(
-				key, cloud_type
-			)
-		)
-		return self._get_application_settings(application_id, key, msg)
-
-	def get_max_recipients(self, cloud_type, application_id=None):
-		key = "{}_MAX_RECIPIENTS".format(cloud_type)
-		msg = (
-			'Set PUSH_NOTIFICATIONS_SETTINGS["{}"] to send messages through {}.'.format(
-				key, cloud_type
-			)
+			'Set PUSH_NOTIFICATIONS_SETTINGS["{}"] to send messages through FCM.'.format(key)
 		)
 		return self._get_application_settings(application_id, key, msg)
 

--- a/push_notifications/gcm.py
+++ b/push_notifications/gcm.py
@@ -5,186 +5,169 @@ Documentation is available on the Firebase Developer website:
 https://firebase.google.com/docs/cloud-messaging/
 """
 
-import json
+from copy import copy
+from typing import List, Union
 
-from django.core.exceptions import ImproperlyConfigured
+from firebase_admin import messaging
+from firebase_admin.exceptions import FirebaseError, InvalidArgumentError
 
-from .compat import Request, urlopen
 from .conf import get_manager
-from .exceptions import GCMError
-from .models import GCMDevice
 
 
 # Valid keys for FCM messages. Reference:
 # https://firebase.google.com/docs/cloud-messaging/http-server-ref
-FCM_TARGETS_KEYS = [
-	"to", "condition", "notification_key"
-]
-FCM_OPTIONS_KEYS = [
-	"collapse_key", "priority", "content_available", "delay_while_idle", "time_to_live",
-	"restricted_package_name", "dry_run", "mutable_content"
-]
+
 FCM_NOTIFICATIONS_PAYLOAD_KEYS = [
 	"title", "body", "icon", "image", "sound", "badge", "color", "tag", "click_action",
 	"body_loc_key", "body_loc_args", "title_loc_key", "title_loc_args", "android_channel_id"
 ]
 
+
+def dict_to_fcm_message(data: dict, dry_run=False, **kwargs) -> messaging.Message:
+	"""
+	Constructs a messaging.Message from the old dictionary.
+
+	FCM_NOTIFICATION_PAYLOAD_KEYS are being put into the AndroidNotification
+	FCM_OPTIONS_KEYS are being put into the AndroidConfig
+	FCM_TARGETS_KEYS is mapped to either topic, token or condition
+
+	If dry_run is included and its value is True, no message will be returned, so nothing is accidentally sent.
+	"""
+
+	data = data.copy()
+
+	# in the old version, dry run was being passed in the data dict
+	# now it needs to be passed as an argument for the send_each method
+	# to not accidentally sending messages, do not return a message here.
+	if "dry_run" in data and data.pop("dry_run", False) or dry_run:
+		return None
+
+	android_notification = None
+
+	notification_payload = {}
+	if "message" in data:
+		notification_payload["body"] = data.pop("message", None)
+	for key in FCM_NOTIFICATIONS_PAYLOAD_KEYS:
+		value_from_extra = data.pop(key, None)
+		if value_from_extra:
+			notification_payload[key] = value_from_extra
+		value_from_kwargs = kwargs.pop(key, None)
+		if value_from_kwargs:
+			notification_payload[key] = value_from_kwargs
+	if notification_payload:
+		# channel id is the one that is different
+		notification_payload["channel_id"] = notification_payload.pop("android_channel_id", None)
+		notification_payload["notification_count"] = notification_payload.pop("badge", None)
+		android_notification = messaging.AndroidNotification(**notification_payload)
+
+	android_config = messaging.AndroidConfig(
+		collapse_key=data.pop("collapse_key", None) or kwargs.get("collapse_key", None),
+		priority=data.pop("priority", None) or kwargs.get("priority", None),
+		ttl=data.pop("time_to_live", None) or kwargs.get("time_to_live", None),
+		restricted_package_name=data.pop("restricted_package_name", None) or kwargs.get(
+			"restricted_package_name", None),
+		data=data,
+		notification=android_notification
+	)
+
+	message = messaging.Message(data=data, android=android_config)
+
+	# set correct receiver
+	to: str = data.pop("to", None) or kwargs.get("to", None)
+	condition = data.pop("condition", None) or kwargs.get("condition", None)
+	notification_key = data.pop(
+		"notification_key", None) or kwargs.get("notification_key", None)
+
+	# topic is set with /topic/ prefix, message can handle this format as well
+	if to and to.startswith("/topic/"):
+		message.topic = to
+	else:
+		message.token = notification_key or to
+	message.condition = condition
+
+	return message
+
+
 def _chunks(l, n):
 	"""
-	Yield successive chunks from list \a l with a minimum size \a n
+	Yield successive chunks from list \a l with a maximum size \a n
 	"""
 	for i in range(0, len(l), n):
 		yield l[i:i + n]
 
 
-def _gcm_send(data, content_type, application_id):
-	key = get_manager().get_gcm_api_key(application_id)
+# Error codes: https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode
+fcm_error_list = [
+	messaging.UnregisteredError,
+	messaging.SenderIdMismatchError,
+	InvalidArgumentError,
+]
 
-	headers = {
-		"Content-Type": content_type,
-		"Authorization": "key=%s" % (key),
-		"Content-Length": str(len(data)),
-	}
-	request = Request(get_manager().get_post_url("GCM", application_id), data, headers)
-	return urlopen(
-		request, timeout=get_manager().get_error_timeout("GCM", application_id)
-	).read().decode("utf-8")
+fcm_error_list_str = [x.code for x in fcm_error_list]
 
 
-def _fcm_send(data, content_type, application_id):
-	key = get_manager().get_fcm_api_key(application_id)
-
-	headers = {
-		"Content-Type": content_type,
-		"Authorization": "key=%s" % (key),
-		"Content-Length": str(len(data)),
-	}
-	request = Request(get_manager().get_post_url("FCM", application_id), data, headers)
-	return urlopen(
-		request, timeout=get_manager().get_error_timeout("FCM", application_id)
-	).read().decode("utf-8")
+def _validate_exception_for_deactivation(exc: Union[FirebaseError]) -> bool:
+	if not exc:
+		return False
+	exc_type = type(exc)
+	if exc_type == str:
+		return exc in fcm_error_list_str
+	return (
+		exc_type == InvalidArgumentError and exc.cause == "Invalid registration"
+	) or (exc_type in fcm_error_list)
 
 
-def _cm_handle_response(registration_ids, response_data, cloud_type, application_id=None):
-	response = response_data
-	if response.get("failure") or response.get("canonical_ids"):
-		ids_to_remove, old_new_ids = [], []
-		throw_error = False
-		for index, result in enumerate(response["results"]):
-			error = result.get("error")
-			if error:
-				# https://firebase.google.com/docs/cloud-messaging/http-server-ref#error-codes
-				# If error is NotRegistered or InvalidRegistration, then we will deactivate devices
-				# because this registration ID is no more valid and can't be used to send messages,
-				# otherwise raise error
-				if error in ("NotRegistered", "InvalidRegistration"):
-					ids_to_remove.append(registration_ids[index])
-				else:
-					throw_error = True
-			result["original_registration_id"] = registration_ids[index]
-			# If registration_id is set, replace the original ID with the new value (canonical ID)
-			# in your server database. Note that the original ID is not part of the result, you need
-			# to obtain it from the list of registration_ids in the request (using the same index).
-			new_id = result.get("registration_id")
-			if new_id:
-				old_new_ids.append((registration_ids[index], new_id))
-
-		if ids_to_remove:
-			removed = GCMDevice.objects.filter(
-				registration_id__in=ids_to_remove, cloud_message_type=cloud_type
-			)
-			removed.update(active=False)
-
-		for old_id, new_id in old_new_ids:
-			_cm_handle_canonical_id(new_id, old_id, cloud_type)
-
-		if throw_error:
-			raise GCMError(response)
-	return response
+def _deactivate_devices_with_error_results(
+	registration_ids: List[str],
+	results: List[Union[messaging.SendResponse, messaging.ErrorInfo]],
+) -> List[str]:
+	if not results:
+		return []
+	if isinstance(results[0], messaging.SendResponse):
+		deactivated_ids = [
+			token
+			for item, token in zip(results, registration_ids)
+			if _validate_exception_for_deactivation(item.exception)
+		]
+	else:
+		deactivated_ids = [
+			registration_ids[x.index]
+			for x in results
+			if _validate_exception_for_deactivation(x.reason)
+		]
+	from .models import GCMDevice
+	GCMDevice.objects.filter(registration_id__in=deactivated_ids).update(active=False)
+	return deactivated_ids
 
 
-def _cm_send_request(
-	registration_ids, data, cloud_type="GCM", application_id=None,
-	use_fcm_notifications=True, **kwargs
+def _prepare_message(message: messaging.Message, token: str):
+	message.token = token
+	return copy(message)
+
+
+def send_message(
+	registration_ids,
+	message: messaging.Message,
+	application_id=None,
+	dry_run=False,
+	**kwargs
 ):
 	"""
-	Sends a FCM or GCM notification to one or more registration_ids as json data.
-	The registration_ids needs to be a list.
+	Sends an FCM notification to one or more registration_ids. The registration_ids
+	can be a list or a single string.
+
+	:param registration_ids: A list of registration ids or a single string
+	:param message: The Message object, use `dict_to_fcm_message` to convert dict to Message
+	:param application_id: The application id to use.
+	:param dry_run: If True, no message will be sent.
+
+	:return: A BatchResponse object
 	"""
-
-	payload = {"registration_ids": registration_ids} if registration_ids else {}
-
-	data = data.copy()
-
-	# If using FCM, optionally autodiscovers notification related keys
-	# https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages
-	if cloud_type == "FCM" and use_fcm_notifications:
-		notification_payload = {}
-		if "message" in data:
-			notification_payload["body"] = data.pop("message", None)
-
-		for key in FCM_NOTIFICATIONS_PAYLOAD_KEYS:
-			value_from_extra = data.pop(key, None)
-			if value_from_extra:
-				notification_payload[key] = value_from_extra
-			value_from_kwargs = kwargs.pop(key, None)
-			if value_from_kwargs:
-				notification_payload[key] = value_from_kwargs
-		if notification_payload:
-			payload["notification"] = notification_payload
-
-	if data:
-		payload["data"] = data
-
-	# Attach any additional non falsy keyword args (targets, options)
-	# See ref : https://firebase.google.com/docs/cloud-messaging/http-server-ref#table1
-	payload.update({
-		k: v for k, v in kwargs.items() if v and (k in FCM_TARGETS_KEYS or k in FCM_OPTIONS_KEYS)
-	})
-
-	# Sort the keys for deterministic output (useful for tests)
-	json_payload = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-	# Sends requests and handles the response
-	if cloud_type == "GCM":
-		response = json.loads(_gcm_send(
-			json_payload, "application/json", application_id=application_id
-		))
-	elif cloud_type == "FCM":
-		response = json.loads(_fcm_send(
-			json_payload, "application/json", application_id=application_id
-		))
-	else:
-		raise ImproperlyConfigured("cloud_type must be FCM or GCM not %s" % str(cloud_type))
-	return _cm_handle_response(registration_ids, response, cloud_type, application_id)
-
-
-def _cm_handle_canonical_id(canonical_id, current_id, cloud_type):
-	"""
-	Handle situation when FCM server response contains canonical ID
-	"""
-	devices = GCMDevice.objects.filter(cloud_message_type=cloud_type)
-	if devices.filter(registration_id=canonical_id, active=True).exists():
-		devices.filter(registration_id=current_id).update(active=False)
-	else:
-		devices.filter(registration_id=current_id).update(registration_id=canonical_id)
-
-
-def send_message(registration_ids, data, cloud_type, application_id=None, **kwargs):
-	"""
-	Sends a FCM (or GCM) notification to one or more registration_ids. The registration_ids
-	can be a list or a single string. This will send the notification as json data.
-
-	A reference of extra keyword arguments sent to the server is available here:
-	https://firebase.google.com/docs/cloud-messaging/http-server-ref#table1
-	"""
-	if cloud_type in ("FCM", "GCM"):
-		max_recipients = get_manager().get_max_recipients(cloud_type, application_id)
-	else:
-		raise ImproperlyConfigured("cloud_type must be FCM or GCM not %s" % str(cloud_type))
+	max_recipients = get_manager().get_max_recipients(application_id)
+	app = get_manager().get_firebase_app(application_id) if application_id else None
 
 	# Checks for valid recipient
-	if registration_ids is None and "/topics/" not in kwargs.get("to", ""):
+	if registration_ids is None and message.topic is None and message.condition is None:
 		return
 
 	# Bundles the registration_ids in an list if only one is sent
@@ -194,14 +177,17 @@ def send_message(registration_ids, data, cloud_type, application_id=None, **kwar
 	# FCM only allows up to 1000 reg ids per bulk message
 	# https://firebase.google.com/docs/cloud-messaging/server#http-request
 	if registration_ids:
-		ret = []
+		ret: List[messaging.SendResponse] = []
 		for chunk in _chunks(registration_ids, max_recipients):
-			ret.append(_cm_send_request(
-				chunk, data, cloud_type=cloud_type, application_id=application_id, **kwargs
-			))
-		return ret[0] if len(ret) == 1 else ret
+			messages = [
+				_prepare_message(message, token) for token in chunk
+			]
+			responses = messaging.send_all(messages, dry_run=dry_run, app=app).responses
+			ret.extend(responses)
+		_deactivate_devices_with_error_results(registration_ids, ret)
+		return messaging.BatchResponse(ret)
 	else:
-		return _cm_send_request(None, data, cloud_type=cloud_type, **kwargs)
+		return messaging.BatchResponse([])
 
 
 send_bulk_message = send_message

--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -1,7 +1,9 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from firebase_admin import messaging
 
 from .fields import HexIntegerField
+from .gcm import dict_to_fcm_message
 from .settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
 
 
@@ -58,29 +60,32 @@ class GCMDeviceManager(models.Manager):
 class GCMDeviceQuerySet(models.query.QuerySet):
 	def send_message(self, message, **kwargs):
 		if self.exists():
-			from .gcm import send_message as gcm_send_message
+			from .gcm import send_message as fcm_send_message
 
-			data = kwargs.pop("extra", {})
-			if message is not None:
-				data["message"] = message
+			if not isinstance(message, messaging.Message):
+				data = kwargs.pop("extra", {})
+				if message is not None:
+					data["message"] = message
+				# transform legacy data to new message object
+				message = dict_to_fcm_message(data, **kwargs)
 
 			app_ids = self.filter(active=True).order_by(
 				"application_id"
 			).values_list("application_id", flat=True).distinct()
-			response = []
-			for cloud_type in ("FCM", "GCM"):
-				for app_id in app_ids:
-					reg_ids = list(
-						self.filter(
-							active=True, cloud_message_type=cloud_type, application_id=app_id).values_list(
-							"registration_id", flat=True
-						)
-					)
-					if reg_ids:
-						r = gcm_send_message(reg_ids, data, cloud_type, application_id=app_id, **kwargs)
-						response.append(r)
 
-			return response
+			responses = []
+			for app_id in app_ids:
+				reg_ids = list(
+					self.filter(
+						active=True, cloud_message_type="FCM", application_id=app_id).values_list(
+						"registration_id", flat=True
+					)
+				)
+				if reg_ids:
+					r = fcm_send_message(reg_ids, message, application_id=app_id, **kwargs)
+					responses.extend(r.responses)
+
+			return messaging.BatchResponse(responses)
 
 
 class GCMDevice(Device):
@@ -94,23 +99,30 @@ class GCMDevice(Device):
 	registration_id = models.TextField(verbose_name=_("Registration ID"), unique=SETTINGS["UNIQUE_REG_ID"])
 	cloud_message_type = models.CharField(
 		verbose_name=_("Cloud Message Type"), max_length=3,
-		choices=CLOUD_MESSAGE_TYPES, default="GCM",
-		help_text=_("You should choose FCM or GCM")
+		choices=CLOUD_MESSAGE_TYPES, default="FCM",
+		help_text=_("You should choose FCM, GCM is deprecated")
 	)
 	objects = GCMDeviceManager()
 
 	class Meta:
-		verbose_name = _("GCM device")
+		verbose_name = _("FCM device")
 
 	def send_message(self, message, **kwargs):
-		from .gcm import send_message as gcm_send_message
+		from .gcm import send_message as fcm_send_message
 
-		data = kwargs.pop("extra", {})
-		if message is not None:
-			data["message"] = message
+		# GCM is not supported.
+		if self.cloud_message_type == "GCM":
+			return
 
-		return gcm_send_message(
-			self.registration_id, data, self.cloud_message_type,
+		if not isinstance(message, messaging.Message):
+			data = kwargs.pop("extra", {})
+			if message is not None:
+				data["message"] = message
+			# transform legacy data to new message object
+			message = dict_to_fcm_message(data, **kwargs)
+
+		return fcm_send_message(
+			self.registration_id, message,
 			application_id=self.application_id, **kwargs
 		)
 

--- a/push_notifications/settings.py
+++ b/push_notifications/settings.py
@@ -7,19 +7,9 @@ PUSH_NOTIFICATIONS_SETTINGS.setdefault(
 	"CONFIG", "push_notifications.conf.LegacyConfig"
 )
 
-# GCM
-PUSH_NOTIFICATIONS_SETTINGS.setdefault(
-	"GCM_POST_URL", "https://android.googleapis.com/gcm/send"
-)
-PUSH_NOTIFICATIONS_SETTINGS.setdefault("GCM_MAX_RECIPIENTS", 1000)
-PUSH_NOTIFICATIONS_SETTINGS.setdefault("GCM_ERROR_TIMEOUT", None)
-
 # FCM
-PUSH_NOTIFICATIONS_SETTINGS.setdefault(
-	"FCM_POST_URL", "https://fcm.googleapis.com/fcm/send"
-)
+PUSH_NOTIFICATIONS_SETTINGS.setdefault("FIREBASE_APP", None)
 PUSH_NOTIFICATIONS_SETTINGS.setdefault("FCM_MAX_RECIPIENTS", 1000)
-PUSH_NOTIFICATIONS_SETTINGS.setdefault("FCM_ERROR_TIMEOUT", None)
 
 # APNS
 if settings.DEBUG:
@@ -37,6 +27,11 @@ PUSH_NOTIFICATIONS_SETTINGS.setdefault(
 )
 
 # WP (WebPush)
+
+PUSH_NOTIFICATIONS_SETTINGS.setdefault(
+	"FCM_POST_URL", "https://fcm.googleapis.com/fcm/send"
+)
+
 PUSH_NOTIFICATIONS_SETTINGS.setdefault("WP_POST_URL", {
 	"CHROME": PUSH_NOTIFICATIONS_SETTINGS["FCM_POST_URL"],
 	"OPERA": PUSH_NOTIFICATIONS_SETTINGS["FCM_POST_URL"],

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,8 @@ APNS =
 
 WP = pywebpush>=1.3.0
 
+FCM = firebase-admin>=5,<6
+
 
 [options.packages.find]
 exclude = tests

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
-from setuptools import setup
 from pathlib import Path
+
+from setuptools import setup
+
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.rst").read_text()

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -1,49 +1,9 @@
 # flake8: noqa
+from firebase_admin.messaging import BatchResponse, SendResponse
 
 
-GCM_JSON = '{"cast_id":108,"success":1,"failure":0,"canonical_ids":0,"results":[{"message_id":"1:08"}]}'
-GCM_JSON_ERROR_NOTREGISTERED = (
-	'{"failure": 1, "canonical_ids": 0, "cast_id": 6358665107659088804, "results":'
-	' [{"error": "NotRegistered"}]}'
-)
-GCM_JSON_ERROR_INVALIDREGISTRATION = (
-	'{"failure": 1, "canonical_ids": 0, "cast_id": 6358665107659088804, "results":'
-	' [{"error": "InvalidRegistration"}]}'
-)
-GCM_JSON_ERROR_MISMATCHSENDERID = (
-	'{"success":0, "failure": 1, "canonical_ids": 0, "results":'
-	' [{"error": "MismatchSenderId"}]}'
-)
-GCM_JSON_CANONICAL_ID = (
-	'{"failure":0,"canonical_ids":1,"success":1,"cast_id":7173139966327257000,"results":'
-	'[{"registration_id":"NEW_REGISTRATION_ID","message_id":"0:1440068396670935%6868637df9fd7ecd"}]}'
-)
-GCM_JSON_CANONICAL_ID_SAME_DEVICE = (
-	'{"failure":0,"canonical_ids":1,"success":1,"cast_id":7173139966327257000,"results":'
-	'[{"registration_id":"bar","message_id":"0:1440068396670935%6868637df9fd7ecd"}]}'
-)
-
-GCM_JSON_MULTIPLE = (
-	'{"multicast_id":108,"success":2,"failure":0,"canonical_ids":0,"results":'
-	'[{"message_id":"1:08"}, {"message_id": "1:09"}]}'
-)
-GCM_JSON_MULTIPLE_ERROR = (
-	'{"success":1, "failure": 2, "canonical_ids": 0, "cast_id": 6358665107659088804, "results":'
-	' [{"error": "NotRegistered"}, {"message_id": "0:1433830664381654%3449593ff9fd7ecd"}, '
-	'{"error": "InvalidRegistration"}]}'
-)
-GCM_JSON_MULTIPLE_ERROR_B = (
-	'{"success":1, "failure": 2, "canonical_ids": 0, "cast_id": 6358665107659088804, '
-	'"results": [{"error": "MismatchSenderId"}, {"message_id": '
-	'"0:1433830664381654%3449593ff9fd7ecd"}, {"error": "InvalidRegistration"}]}'
-)
-GCM_JSON_MULTIPLE_CANONICAL_ID = (
-	'{"failure":0,"canonical_ids":1,"success":2,"multicast_id":7173139966327257000,"results":'
-	'[{"registration_id":"NEW_REGISTRATION_ID","message_id":"0:1440068396670935%6868637df9fd7ecd"},'
-	'{"message_id":"0:1440068396670937%6868637df9fd7ecd"}]}'
-)
-GCM_JSON_MULTIPLE_CANONICAL_ID_SAME_DEVICE = (
-	'{"failure":0,"canonical_ids":1,"success":2,"multicast_id":7173139966327257000,'
-	'"results":[{"registration_id":"bar","message_id":"0:1440068396670935%6868637df9fd7ecd"}'
-	',{"message_id":"0:1440068396670937%6868637df9fd7ecd"}]}'
-)
+FCM_SUCCESS = BatchResponse([SendResponse(resp={"name": "abc"}, exception=None)])
+FCM_SUCCESS_MULTIPLE = BatchResponse([
+	SendResponse(resp={"name": "abc"}, exception=None),
+	SendResponse(resp={"name": "abc2"}, exception=None)
+], )

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -70,7 +70,6 @@ class AppConfigTestCase(TestCase):
 			"APPLICATIONS": {
 				application_id: {
 					"PLATFORM": "FCM",
-					"API_KEY": "[my_api_key]"
 				}
 			}
 		}
@@ -79,23 +78,6 @@ class AppConfigTestCase(TestCase):
 
 		with self.assertRaises(ImproperlyConfigured):
 			manager._get_application_settings(application_id, "APNS", "CERTIFICATE")
-
-	def test_missing_setting(self):
-		"""
-		Missing application settings raises ImproperlyConfigured.
-		"""
-
-		application_id = "my_fcm_app"
-		PUSH_SETTINGS = {
-			"APPLICATIONS": {
-				application_id: {
-					"PLATFORM": "FCM"
-				}
-			}
-		}
-
-		with self.assertRaises(ImproperlyConfigured):
-			AppConfig(PUSH_SETTINGS)
 
 	def test_validate_apns_config(self):
 		"""
@@ -183,20 +165,19 @@ class AppConfigTestCase(TestCase):
 			"APPLICATIONS": {
 				"my_fcm_app": {
 					"PLATFORM": "FCM",
-					"API_KEY": "...",
-					"POST_URL": "...",
 					"MAX_RECIPIENTS": "...",
-					"ERROR_TIMEOUT": "...",
+					"FIREBASE_APP": "...",
 				}
 			}
 		}
 		AppConfig(PUSH_SETTINGS)
 
-		# missing required settings
+		# old API_KEY does not work anymore
 		PUSH_SETTINGS = {
 			"APPLICATIONS": {
 				"my_fcm_app": {
 					"PLATFORM": "FCM",
+					"API_KEY": "...",
 				}
 			}
 		}
@@ -209,7 +190,6 @@ class AppConfigTestCase(TestCase):
 			"APPLICATIONS": {
 				"my_fcm_app": {
 					"PLATFORM": "FCM",
-					"API_KEY": "...",
 				}
 			}
 		}
@@ -217,59 +197,8 @@ class AppConfigTestCase(TestCase):
 		manager = AppConfig(PUSH_SETTINGS)
 		app_config = manager._settings["APPLICATIONS"]["my_fcm_app"]
 
-		assert app_config["POST_URL"] == "https://fcm.googleapis.com/fcm/send"
 		assert app_config["MAX_RECIPIENTS"] == 1000
-		assert app_config["ERROR_TIMEOUT"] is None
-
-	def test_get_allowed_settings_gcm(self):
-		"""Verify the settings allowed for GCM platform."""
-
-		#
-		# all settings specified, required and optional, does not raise an error.
-		#
-		PUSH_SETTINGS = {
-			"APPLICATIONS": {
-				"my_gcm_app": {
-					"PLATFORM": "GCM",
-					"API_KEY": "...",
-					"POST_URL": "...",
-					"MAX_RECIPIENTS": "...",
-					"ERROR_TIMEOUT": "...",
-				}
-			}
-		}
-		AppConfig(PUSH_SETTINGS)
-
-		#
-		# missing required settings
-		#
-		PUSH_SETTINGS = {
-			"APPLICATIONS": {
-				"my_gcm_app": {
-					"PLATFORM": "GCM",
-				}
-			}
-		}
-
-		with self.assertRaises(ImproperlyConfigured):
-			AppConfig(PUSH_SETTINGS)
-
-		# all optional settings have default values
-		PUSH_SETTINGS = {
-			"APPLICATIONS": {
-				"my_gcm_app": {
-					"PLATFORM": "GCM",
-					"API_KEY": "...",
-				}
-			}
-		}
-
-		manager = AppConfig(PUSH_SETTINGS)
-		app_config = manager._settings["APPLICATIONS"]["my_gcm_app"]
-
-		assert app_config["POST_URL"] == "https://android.googleapis.com/gcm/send"
-		assert app_config["MAX_RECIPIENTS"] == 1000
-		assert app_config["ERROR_TIMEOUT"] is None
+		assert app_config["FIREBASE_APP"] is None
 
 	def test_get_allowed_settings_wns(self):
 		"""

--- a/tests/test_dict_to_message.py
+++ b/tests/test_dict_to_message.py
@@ -1,0 +1,119 @@
+from django.test import TestCase
+from firebase_admin.messaging import Message
+
+from push_notifications.gcm import dict_to_fcm_message
+
+
+class DictToMessageTest(TestCase):
+
+	def test_dry_run_none(self):
+		message_no = dict_to_fcm_message({"message": "Hello World", "dry_run": True})
+		message_no_kwargs = dict_to_fcm_message({"message": "Hello World"}, dry_run=True)
+		message_yes = dict_to_fcm_message({"message": "Hello World", "dry_run": False})
+
+		assert message_no is None
+		assert message_no_kwargs is None
+		assert isinstance(message_yes, Message)
+		assert message_yes.android.notification.body == "Hello World"
+
+	def test_kwargs(self):
+		message = dict_to_fcm_message(
+			{},
+			time_to_live=3600,
+			collapse_key="collapse key",
+			priority="high",
+			restricted_package_name="restricted.package.name"
+		)
+
+		assert message.android.ttl == 3600
+		assert message.android.collapse_key == "collapse key"
+		assert message.android.priority == "high"
+		assert message.android.restricted_package_name == "restricted.package.name"
+
+	def test_payload_keys(self):
+		"""
+		old FCM_NOTIFICATIONS_PAYLOAD_KEYS payload is mapped to message object correctly
+		"""
+		payload = {
+			"message": "Hello World",
+			"title": "Title",
+			"body": "Body",
+			"icon": "Icon",
+			"image": "Image",
+			"sound": "Sound",
+			"badge": "10",
+			"color": "Color",
+			"tag": "Tag",
+			"click_action": "Click Action",
+			"body_loc_key": "Body Loc Key",
+			"body_loc_args": "Body Loc Args",
+			"title_loc_key": "Title Loc Key",
+			"title_loc_args": "Title Loc Args",
+			"android_channel_id": "Android Channel Id",
+		}
+
+		message = dict_to_fcm_message(payload)
+
+		assert message.android.notification.title == "Title"
+		assert message.android.notification.body == "Body"
+		assert message.android.notification.icon == "Icon"
+		assert message.android.notification.image == "Image"
+		assert message.android.notification.sound == "Sound"
+		assert message.android.notification.notification_count == "10"
+		assert message.android.notification.color == "Color"
+		assert message.android.notification.tag == "Tag"
+		assert message.android.notification.click_action == "Click Action"
+		assert message.android.notification.body_loc_key == "Body Loc Key"
+		assert message.android.notification.body_loc_args == "Body Loc Args"
+		assert message.android.notification.title_loc_key == "Title Loc Key"
+		assert message.android.notification.title_loc_args == "Title Loc Args"
+		assert message.android.notification.channel_id == "Android Channel Id"
+
+	def test_fcm_options(self):
+		"""
+		old FCM_OPTIONS_KEYS payload is mapped to message object correctly
+		"""
+
+		payload = {
+			"message": "Hello World",
+			"collapse_key": "Collapse Key",
+			"priority": "High",
+			"time_to_live": 3600,
+			"restricted_package_name": "restricted.package.name",
+		}
+
+		message = dict_to_fcm_message(payload)
+
+		assert message.android.collapse_key == "Collapse Key"
+		assert message.android.priority == "High"
+		assert message.android.ttl == 3600
+		assert message.android.restricted_package_name == "restricted.package.name"
+
+	def test_receiver_mapping_topic(self):
+		payload = {
+			"message": "Hello World",
+			"to": "/topic/...",
+		}
+
+		message = dict_to_fcm_message(payload)
+		assert message.topic == "/topic/..."
+		assert message.token is None
+
+	def test_receiver_mapping_token(self):
+		payload = {
+			"message": "Hello World",
+			"to": "...",
+		}
+
+		message = dict_to_fcm_message(payload)
+		assert message.topic is None
+		assert message.token == "..."
+
+	def test_receiver_mapping_condition(self):
+		payload = {
+			"message": "Hello World",
+			"condition": "...",
+		}
+
+		message = dict_to_fcm_message(payload)
+		assert message.condition == "..."

--- a/tests/test_gcm_push_payload.py
+++ b/tests/test_gcm_push_payload.py
@@ -1,76 +1,80 @@
 from unittest import mock
 
+from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
+from firebase_admin.messaging import Message
 
-from push_notifications.gcm import send_bulk_message, send_message
+from push_notifications.gcm import dict_to_fcm_message, send_message
 
-from .responses import GCM_JSON, GCM_JSON_MULTIPLE
+from .responses import FCM_SUCCESS
 
 
 class GCMPushPayloadTest(TestCase):
 
 	def test_fcm_push_payload(self):
-		with mock.patch("push_notifications.gcm._fcm_send", return_value=GCM_JSON) as p:
-			send_message("abc", {"message": "Hello world"}, "FCM")
-			p.assert_called_once_with(
-				b'{"notification":{"body":"Hello world"},"registration_ids":["abc"]}',
-				"application/json", application_id=None)
+		with mock.patch("firebase_admin.messaging.send_all", return_value=FCM_SUCCESS) as p:
+			message = dict_to_fcm_message({"message": "Hello world"})
 
-	def test_push_payload_with_app_id(self):
-		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON) as p:
-			send_message("abc", {"message": "Hello world"}, "GCM")
-			p.assert_called_once_with(
-				b'{"data":{"message":"Hello world"},"registration_ids":["abc"]}',
-				"application/json", application_id=None)
-		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON) as p:
-			send_message("abc", {"message": "Hello world"}, "GCM")
-			p.assert_called_once_with(
-				b'{"data":{"message":"Hello world"},"registration_ids":["abc"]}',
-				"application/json", application_id=None)
+			send_message("abc", message)
 
-	def test_fcm_push_payload_params(self):
-		with mock.patch("push_notifications.gcm._fcm_send", return_value=GCM_JSON) as p:
-			send_message(
-				"abc",
-				{"message": "Hello world", "title": "Push notification", "other": "misc"},
-				"FCM",
-				delay_while_idle=True, time_to_live=3600, foo="bar",
-			)
-			p.assert_called_once_with(
-				b'{"data":{"other":"misc"},"delay_while_idle":true,'
-				b'"notification":{"body":"Hello world","title":"Push notification"},'
-				b'"registration_ids":["abc"],"time_to_live":3600}',
-				"application/json", application_id=None)
+			# one call
+			self.assertEqual(len(p.mock_calls), 1)
+			call = p.mock_calls[0]
+
+			# only messages is args, dry_run and app are in kwargs
+			self.assertEqual(len(call.args), 1)
+
+			self.assertTrue("dry_run" in call.kwargs)
+			self.assertFalse(call.kwargs["dry_run"])
+			self.assertTrue("app" in call.kwargs)
+			self.assertIsNone(call.kwargs["app"])
+
+			# only one message
+			self.assertEqual(len(call.args[0]), 1)
+
+			message = call.args[0][0]
+			self.assertIsInstance(message, Message)
+			self.assertEqual(message.token, "abc")
+			self.assertEqual(message.android.notification.body, "Hello world")
 
 	def test_fcm_push_payload_many(self):
-		with mock.patch("push_notifications.gcm._fcm_send", return_value=GCM_JSON_MULTIPLE) as p:
-			send_bulk_message(["abc", "123"], {"message": "Hello world"}, "FCM")
-			p.assert_called_once_with(
-				b'{"notification":{"body":"Hello world"},"registration_ids":["abc","123"]}',
-				"application/json", application_id=None)
+		with mock.patch("firebase_admin.messaging.send_all", return_value=FCM_SUCCESS) as p:
+			message = dict_to_fcm_message({"message": "Hello world"})
 
-	def test_gcm_push_payload(self):
-		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON) as p:
-			send_message("abc", {"message": "Hello world"}, "GCM")
-			p.assert_called_once_with(
-				b'{"data":{"message":"Hello world"},"registration_ids":["abc"]}',
-				"application/json", application_id=None)
+			send_message(["abc", "123"], message)
 
-	def test_gcm_push_payload_params(self):
-		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON) as p:
-			send_message(
-				"abc", {"message": "Hello world"}, "GCM",
-				delay_while_idle=True, time_to_live=3600, foo="bar",
-			)
-			p.assert_called_once_with(
-				b'{"data":{"message":"Hello world"},"delay_while_idle":true,'
-				b'"registration_ids":["abc"],"time_to_live":3600}',
-				"application/json", application_id=None)
+			# one call
+			self.assertEqual(len(p.mock_calls), 1)
+			call = p.mock_calls[0]
 
-	def test_gcm_push_payload_many(self):
-		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON_MULTIPLE) as p:
-			send_bulk_message(["abc", "123"], {"message": "Hello world"}, "GCM")
-			p.assert_called_once_with(
-				b'{"data":{"message":"Hello world"},"registration_ids":["abc","123"]}',
-				"application/json",
-				application_id=None)
+			# only messages is args, dry_run and app are in kwargs
+			self.assertEqual(len(call.args), 1)
+			messages_arg = call.args[0]
+
+			self.assertTrue("dry_run" in call.kwargs)
+			self.assertFalse(call.kwargs["dry_run"])
+			self.assertTrue("app" in call.kwargs)
+			self.assertIsNone(call.kwargs["app"])
+
+			# two message
+			self.assertEqual(len(messages_arg), 2)
+
+			message_one = messages_arg[0]
+			self.assertIsInstance(message_one, Message)
+			self.assertEqual(message_one.token, "abc")
+			self.assertEqual(message_one.android.notification.body, "Hello world")
+
+			message_two = messages_arg[1]
+			self.assertIsInstance(message_two, Message)
+			self.assertEqual( message_two.token,"123")
+			self.assertEqual( message_two.android.notification.body, "Hello world")
+
+	def test_push_payload_with_app_id(self):
+		with self.assertRaises(ImproperlyConfigured) as ic:
+			send_message("abc", {"message": "Hello world"}, application_id="test")
+
+		self.assertEqual(
+			str(ic.exception),
+			("LegacySettings does not support application_id. To enable "
+			 "multiple application support, use push_notifications.conf.AppSettings.")
+		)

--- a/tests/test_legacy_config.py
+++ b/tests/test_legacy_config.py
@@ -1,43 +1,13 @@
 from unittest import mock
 
-from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 
-from push_notifications.conf import LegacyConfig, get_manager
+from push_notifications.conf import get_manager
 from push_notifications.exceptions import WebPushError
 from push_notifications.webpush import webpush_send_message
 
 
 class LegacyConfigTestCase(TestCase):
-	def test_get_error_timeout(self):
-
-		config = LegacyConfig()
-
-		# confirm default value is None
-		assert config.get_error_timeout("GCM") is None
-
-		# confirm default value is None
-		assert config.get_error_timeout("FCM") is None
-
-		# confirm legacy does not support GCM with an application_id
-		with self.assertRaises(ImproperlyConfigured) as ic:
-			config.get_error_timeout("GCM", "my_app_id")
-
-		self.assertEqual(
-			str(ic.exception),
-			"LegacySettings does not support application_id. To enable multiple"
-			" application support, use push_notifications.conf.AppSettings."
-		)
-
-		# confirm legacy does not support FCM with an application_id
-		with self.assertRaises(ImproperlyConfigured) as ic:
-			config.get_error_timeout("FCM", "my_app_id")
-
-		self.assertEqual(
-			str(ic.exception),
-			"LegacySettings does not support application_id. To enable multiple"
-			" application support, use push_notifications.conf.AppSettings."
-		)
 
 	def test_immutable_wp_claims(self):
 		self.endpoint = "https://updates.push.services.mozilla.com/wpush/v2/token"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,11 +1,12 @@
-import json
 from unittest import mock
 
 from django.test import TestCase
 from django.utils import timezone
+from firebase_admin import messaging
+from firebase_admin.exceptions import InvalidArgumentError
+from firebase_admin.messaging import BatchResponse, Message, SendResponse
 
-from push_notifications.conf import AppConfig
-from push_notifications.gcm import GCMError, send_bulk_message
+from push_notifications.gcm import dict_to_fcm_message, send_bulk_message
 from push_notifications.models import APNSDevice, GCMDevice
 
 from . import responses
@@ -34,313 +35,121 @@ class GCMModelTestCase(TestCase):
 		assert device.date_created is not None
 		assert device.date_created.date() == timezone.now().date()
 
-	def test_gcm_send_message(self):
-		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="GCM")
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=responses.GCM_JSON
-		) as p:
-			device.send_message("Hello world")
-			p.assert_called_once_with(
-				json.dumps({
-					"data": {"message": "Hello world"},
-					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-				"application/json", application_id=None
-			)
-
-	def test_gcm_send_message_extra(self):
-		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="GCM")
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=responses.GCM_JSON
-		) as p:
-			device.send_message("Hello world", extra={"foo": "bar"}, collapse_key="test_key")
-			p.assert_called_once_with(
-				json.dumps({
-					"collapse_key": "test_key",
-					"data": {"message": "Hello world", "foo": "bar"},
-					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-				"application/json", application_id=None
-			)
-
-	def test_gcm_send_message_extra_multiple_device(self):
-		my_manager = AppConfig(settings={
-			"APPLICATIONS": {
-				"my_fcm_app": {
-					"PLATFORM": "FCM",
-					"API_KEY": "...",
-				},
-				"other_fcm_app": {
-					"PLATFORM": "FCM",
-					"API_KEY": "...",
-				}
-			}
-		})
-
-		with mock.patch(
-			"push_notifications.gcm.get_manager", return_value=my_manager
-		):
-			# Reload the manager with new settings
-			GCMDevice.objects.create(
-				registration_id="abc", cloud_message_type="FCM", application_id="my_fcm_app"
-			)
-			GCMDevice.objects.create(
-				registration_id="def", cloud_message_type="FCM", application_id="other_fcm_app"
-			)
-			with mock.patch(
-				"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON
-			) as p:
-				GCMDevice.objects.all().send_message(
-					None, extra={"title": "bar", "body": "foo"}, collapse_key="test_key"
-				)
-				self.assertEqual(p.call_count, 2)
-				p.assert_has_calls([
-					mock.call(
-						json.dumps({
-							"collapse_key": "test_key",
-							"notification": {"title": "bar", "body": "foo"},
-							"registration_ids": ["abc"]
-						}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-						"application/json", application_id="my_fcm_app"
-					),
-					mock.call(
-						json.dumps({
-							"collapse_key": "test_key",
-							"notification": {"title": "bar", "body": "foo"},
-							"registration_ids": ["def"]
-						}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-						"application/json", application_id="other_fcm_app"
-					),
-				])
-
-	def test_gcm_send_message_collapse_key(self):
-		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="GCM")
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=responses.GCM_JSON
-		) as p:
-			device.send_message("Hello world", collapse_key="test_key")
-			p.assert_called_once_with(
-				json.dumps({
-					"data": {"message": "Hello world"},
-					"registration_ids": ["abc"],
-					"collapse_key": "test_key"
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-				"application/json", application_id=None
-			)
-
-	def test_gcm_send_message_to_multiple_devices(self):
-		self._create_devices(["abc", "abc1"])
-
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=responses.GCM_JSON_MULTIPLE
-		) as p:
-			GCMDevice.objects.all().send_message("Hello world")
-			p.assert_called_once_with(
-				json.dumps({
-					"data": {"message": "Hello world"},
-					"registration_ids": ["abc", "abc1"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-				"application/json", application_id=None
-			)
-
-	def test_gcm_send_message_active_devices(self):
-		GCMDevice.objects.create(registration_id="abc", active=True, cloud_message_type="GCM")
-		GCMDevice.objects.create(registration_id="xyz", active=False, cloud_message_type="GCM")
-
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=responses.GCM_JSON_MULTIPLE
-		) as p:
-			GCMDevice.objects.all().send_message("Hello world")
-			p.assert_called_once_with(
-				json.dumps({
-					"data": {"message": "Hello world"},
-					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-				"application/json", application_id=None
-			)
-
-	def test_gcm_send_message_collapse_to_multiple_devices(self):
-		self._create_devices(["abc", "abc1"])
-
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=responses.GCM_JSON_MULTIPLE
-		) as p:
-				GCMDevice.objects.all().send_message("Hello world", collapse_key="test_key")
-				p.assert_called_once_with(
-					json.dumps({
-						"collapse_key": "test_key",
-						"data": {"message": "Hello world"},
-						"registration_ids": ["abc", "abc1"]
-					}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-					"application/json", application_id=None
-				)
-
-	def test_gcm_send_message_to_single_device_with_error(self):
-		# these errors are device specific, device.active will be set false
-		devices = ["abc", "abc1"]
-		self._create_devices(devices)
-
-		errors = [
-			responses.GCM_JSON_ERROR_NOTREGISTERED,
-			responses.GCM_JSON_ERROR_INVALIDREGISTRATION
-		]
-		for index, error in enumerate(errors):
-			with mock.patch(
-				"push_notifications.gcm._gcm_send", return_value=error):
-				device = GCMDevice.objects.get(registration_id=devices[index])
-				device.send_message("Hello World!")
-				assert GCMDevice.objects.get(registration_id=devices[index]).active is False
-
-	def test_gcm_send_message_to_single_device_with_error_mismatch(self):
-		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="GCM")
-
-		with mock.patch(
-			"push_notifications.gcm._gcm_send",
-			return_value=responses.GCM_JSON_ERROR_MISMATCHSENDERID
-		):
-			# these errors are not device specific, GCMError should be thrown
-			with self.assertRaises(GCMError):
-				device.send_message("Hello World!")
-			assert GCMDevice.objects.get(registration_id="abc").active is True
-
-	def test_gcm_send_message_to_multiple_devices_with_error(self):
-		self._create_devices(["abc", "abc1", "abc2"])
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=responses.GCM_JSON_MULTIPLE_ERROR
-		):
-			devices = GCMDevice.objects.all()
-			devices.send_message("Hello World")
-			assert not GCMDevice.objects.get(registration_id="abc").active
-			assert GCMDevice.objects.get(registration_id="abc1").active
-			assert not GCMDevice.objects.get(registration_id="abc2").active
-
-	def test_gcm_send_message_to_multiple_devices_with_error_b(self):
-		self._create_devices(["abc", "abc1", "abc2"])
-
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=responses.GCM_JSON_MULTIPLE_ERROR_B
-		):
-			devices = GCMDevice.objects.all()
-			with self.assertRaises(GCMError):
-				devices.send_message("Hello World")
-			assert GCMDevice.objects.get(registration_id="abc").active is True
-			assert GCMDevice.objects.get(registration_id="abc1").active is True
-			assert GCMDevice.objects.get(registration_id="abc2").active is False
-
-	def test_gcm_send_message_to_multiple_devices_with_canonical_id(self):
-		self._create_devices(["foo", "bar"])
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=responses.GCM_JSON_MULTIPLE_CANONICAL_ID
-		):
-			GCMDevice.objects.all().send_message("Hello World")
-			assert not GCMDevice.objects.filter(registration_id="foo").exists()
-			assert GCMDevice.objects.filter(registration_id="bar").exists()
-			assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists() is True
-
-	def test_gcm_send_message_to_single_user_with_canonical_id(self):
-		old_registration_id = "foo"
-		self._create_devices([old_registration_id])
-
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=responses.GCM_JSON_CANONICAL_ID
-		):
-			GCMDevice.objects.get(registration_id=old_registration_id).send_message("Hello World")
-			assert not GCMDevice.objects.filter(registration_id=old_registration_id).exists()
-			assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists()
-
-	def test_gcm_send_message_to_same_devices_with_canonical_id(self):
-		first_device = GCMDevice.objects.create(
-			registration_id="foo", active=True, cloud_message_type="GCM"
-		)
-		second_device = GCMDevice.objects.create(
-			registration_id="bar", active=False, cloud_message_type="GCM"
-		)
-
-		with mock.patch(
-			"push_notifications.gcm._gcm_send",
-			return_value=responses.GCM_JSON_CANONICAL_ID_SAME_DEVICE
-		):
-			GCMDevice.objects.all().send_message("Hello World")
-
-		assert first_device.active is True
-		assert second_device.active is False
-
-	def test_gcm_send_message_with_no_reg_ids(self):
-		self._create_devices(["abc", "abc1"])
-
-		with mock.patch("push_notifications.gcm._cm_send_request", return_value="") as p:
-			GCMDevice.objects.filter(registration_id="xyz").send_message("Hello World")
-			p.assert_not_called()
-
-		with mock.patch("push_notifications.gcm._cm_send_request", return_value="") as p:
-			reg_ids = [obj.registration_id for obj in GCMDevice.objects.all()]
-			send_bulk_message(reg_ids, {"message": "Hello World"}, "GCM")
-			p.assert_called_once_with(
-				["abc", "abc1"], {"message": "Hello World"}, cloud_type="GCM", application_id=None
-			)
-
 	def test_fcm_send_message(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
 		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON
+			"firebase_admin.messaging.send_all", return_value=responses.FCM_SUCCESS
 		) as p:
 			device.send_message("Hello world")
-			p.assert_called_once_with(
-				json.dumps({
-					"notification": {"body": "Hello world"},
-					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-				"application/json", application_id=None
-			)
+
+			# one call
+			self.assertEqual(len(p.mock_calls), 1)
+			call = p.mock_calls[0]
+
+			# only messages is args, dry_run and app are in kwargs
+			self.assertEqual(len(call.args), 1)
+
+			self.assertTrue("dry_run" in call.kwargs)
+			self.assertFalse(call.kwargs["dry_run"])
+			self.assertTrue("app" in call.kwargs)
+			self.assertIsNone(call.kwargs["app"])
+
+			# only one message
+			self.assertEqual(len(call.args[0]), 1)
+
+			message = call.args[0][0]
+			self.assertIsInstance(message, Message)
+			self.assertEqual(message.token, "abc")
+			self.assertEqual(message.android.notification.body, "Hello world")
 
 	def test_fcm_send_message_extra_data(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
 		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON
+			"firebase_admin.messaging.send_all", return_value=responses.FCM_SUCCESS
 		) as p:
 			device.send_message("Hello world", extra={"foo": "bar"})
-			p.assert_called_once_with(
-				json.dumps({
-					"data": {"foo": "bar"},
-					"notification": {"body": "Hello world"},
-					"registration_ids": ["abc"],
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",
-				application_id=None
-			)
+
+			self.assertEqual(len(p.mock_calls), 1)
+			call = p.mock_calls[0]
+
+			# only messages is args, dry_run and app are in kwargs
+			self.assertEqual(len(call.args), 1)
+
+			self.assertTrue("dry_run" in call.kwargs)
+			self.assertFalse(call.kwargs["dry_run"])
+			self.assertTrue("app" in call.kwargs)
+			self.assertIsNone(call.kwargs["app"])
+
+			# only one message
+			self.assertEqual(len(call.args[0]), 1)
+
+			message = call.args[0][0]
+			self.assertIsInstance(message, Message)
+			self.assertEqual(message.token, "abc")
+			self.assertEqual(message.android.notification.body, "Hello world")
+			self.assertEqual(message.data, {"foo": "bar"})
 
 	def test_fcm_send_message_extra_options(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
 		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON
+			"firebase_admin.messaging.send_all", return_value=responses.FCM_SUCCESS
 		) as p:
 			device.send_message("Hello world", collapse_key="test_key", foo="bar")
-			p.assert_called_once_with(
-				json.dumps({
-					"collapse_key": "test_key",
-					"notification": {"body": "Hello world"},
-					"registration_ids": ["abc"],
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",
-				application_id=None
-			)
+
+			self.assertEqual(len(p.mock_calls), 1)
+			call = p.mock_calls[0]
+
+			# only messages is args, dry_run and app are in kwargs
+			self.assertEqual(len(call.args), 1)
+
+			self.assertTrue("dry_run" in call.kwargs)
+			self.assertFalse(call.kwargs["dry_run"])
+			self.assertTrue("app" in call.kwargs)
+			self.assertIsNone(call.kwargs["app"])
+
+			# only one message
+			self.assertEqual(len(call.args[0]), 1)
+
+			message = call.args[0][0]
+			self.assertIsInstance(message, Message)
+			self.assertEqual(message.token, "abc")
+			self.assertEqual(message.android.notification.body, "Hello world")
+			self.assertEqual(message.android.collapse_key, "test_key")
+			self.assertFalse(message.data)
 
 	def test_fcm_send_message_extra_notification(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
 		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON
+			"firebase_admin.messaging.send_all", return_value=responses.FCM_SUCCESS
 		) as p:
 			device.send_message("Hello world", extra={"icon": "test_icon"}, title="test")
-			p.assert_called_once_with(
-				json.dumps({
-					"notification": {"body": "Hello world", "title": "test", "icon": "test_icon"},
-					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-				"application/json", application_id=None
-			)
+
+			self.assertEqual(len(p.mock_calls), 1)
+			call = p.mock_calls[0]
+
+			# only messages is args, dry_run and app are in kwargs
+			self.assertEqual(len(call.args), 1)
+
+			self.assertTrue("dry_run" in call.kwargs)
+			self.assertFalse(call.kwargs["dry_run"])
+			self.assertTrue("app" in call.kwargs)
+			self.assertIsNone(call.kwargs["app"])
+
+			# only one message
+			self.assertEqual(len(call.args[0]), 1)
+
+			message = call.args[0][0]
+			self.assertIsInstance(message, Message)
+			self.assertEqual(message.token, "abc")
+			self.assertEqual(message.android.notification.body, "Hello world")
+			self.assertEqual(message.android.notification.title, "test")
+			self.assertEqual(message.android.notification.icon, "test_icon")
+			self.assertFalse(message.data)
 
 	def test_fcm_send_message_extra_options_and_notification_and_data(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
 		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON
+			"firebase_admin.messaging.send_all", return_value=responses.FCM_SUCCESS
 		) as p:
 			device.send_message(
 				"Hello world",
@@ -348,167 +157,212 @@ class GCMModelTestCase(TestCase):
 				title="test",
 				collapse_key="test_key"
 			)
-			p.assert_called_once_with(
-				json.dumps({
-					"notification": {"body": "Hello world", "title": "test", "icon": "test_icon"},
-					"data": {"foo": "bar"},
-					"registration_ids": ["abc"],
-					"collapse_key": "test_key"
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-				"application/json", application_id=None
-			)
+
+			self.assertEqual(len(p.mock_calls), 1)
+			call = p.mock_calls[0]
+
+			# only messages is args, dry_run and app are in kwargs
+			self.assertEqual(len(call.args), 1)
+
+			self.assertTrue("dry_run" in call.kwargs)
+			self.assertFalse(call.kwargs["dry_run"])
+			self.assertTrue("app" in call.kwargs)
+			self.assertIsNone(call.kwargs["app"])
+
+			# only one message
+			self.assertEqual(len(call.args[0]), 1)
+
+			message = call.args[0][0]
+			self.assertIsInstance(message, Message)
+			self.assertEqual(message.token, "abc")
+			self.assertEqual(message.android.collapse_key, "test_key")
+			self.assertEqual(message.android.notification.body, "Hello world")
+			self.assertEqual(message.android.notification.title, "test")
+			self.assertEqual(message.android.notification.icon, "test_icon")
+			self.assertEqual(message.data, {"foo": "bar"})
 
 	def test_fcm_send_message_to_multiple_devices(self):
 		self._create_fcm_devices(["abc", "abc1"])
 
 		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON_MULTIPLE
+			"firebase_admin.messaging.send_all", return_value=responses.FCM_SUCCESS_MULTIPLE
 		) as p:
 			GCMDevice.objects.all().send_message("Hello world")
-			p.assert_called_once_with(
-				json.dumps({
-					"notification": {"body": "Hello world"},
-					"registration_ids": ["abc", "abc1"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-				"application/json", application_id=None
-			)
+
+			self.assertEqual(len(p.mock_calls), 1)
+			call = p.mock_calls[0]
+
+			# only messages is args, dry_run and app are in kwargs
+			self.assertEqual(len(call.args), 1)
+
+			self.assertTrue("dry_run" in call.kwargs)
+			self.assertFalse(call.kwargs["dry_run"])
+			self.assertTrue("app" in call.kwargs)
+			self.assertIsNone(call.kwargs["app"])
+
+			# two messages
+			self.assertEqual(len(call.args[0]), 2)
+
+			message_one = call.args[0][0]
+			message_two = call.args[0][1]
+			self.assertIsInstance(message_one, Message)
+			self.assertIsInstance(message_two, Message)
+			self.assertEqual(message_one.token, "abc")
+			self.assertEqual(message_two.token, "abc1")
+			self.assertEqual(message_one.android.notification.body, "Hello world")
+			self.assertEqual(message_two.android.notification.body, "Hello world")
 
 	def test_fcm_send_message_active_devices(self):
 		GCMDevice.objects.create(registration_id="abc", active=True, cloud_message_type="FCM")
 		GCMDevice.objects.create(registration_id="xyz", active=False, cloud_message_type="FCM")
 
 		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON_MULTIPLE
+			"firebase_admin.messaging.send_all", return_value=responses.FCM_SUCCESS_MULTIPLE
 		) as p:
 			GCMDevice.objects.all().send_message("Hello world")
-			p.assert_called_once_with(
-				json.dumps({
-					"notification": {"body": "Hello world"},
-					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-				"application/json", application_id=None
-			)
+
+			self.assertEqual(len(p.mock_calls), 1)
+			call = p.mock_calls[0]
+
+			# only messages is args, dry_run and app are in kwargs
+			self.assertEqual(len(call.args), 1)
+
+			self.assertTrue("dry_run" in call.kwargs)
+			self.assertFalse(call.kwargs["dry_run"])
+			self.assertTrue("app" in call.kwargs)
+			self.assertIsNone(call.kwargs["app"])
+
+			# only one message (one is inactive)
+			self.assertEqual(len(call.args[0]), 1)
+			message_one = call.args[0][0]
+
+			self.assertIsInstance(message_one, Message)
+			self.assertEqual(message_one.token, "abc")
+			self.assertEqual(message_one.android.notification.body, "Hello world")
 
 	def test_fcm_send_message_collapse_to_multiple_devices(self):
 		self._create_fcm_devices(["abc", "abc1"])
 
 		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON_MULTIPLE
+			"firebase_admin.messaging.send_all", return_value=responses.FCM_SUCCESS_MULTIPLE
 		) as p:
-				GCMDevice.objects.all().send_message("Hello world", collapse_key="test_key")
-				p.assert_called_once_with(
-					json.dumps({
-						"collapse_key": "test_key",
-						"notification": {"body": "Hello world"},
-						"registration_ids": ["abc", "abc1"]
-					}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
-					"application/json", application_id=None
-				)
+			GCMDevice.objects.all().send_message("Hello world", collapse_key="test_key")
+
+			self.assertEqual(len(p.mock_calls), 1)
+			call = p.mock_calls[0]
+
+			# only messages is args, dry_run and app are in kwargs
+			self.assertEqual(len(call.args), 1)
+
+			self.assertTrue("dry_run" in call.kwargs)
+			self.assertFalse(call.kwargs["dry_run"])
+			self.assertTrue("app" in call.kwargs)
+			self.assertIsNone(call.kwargs["app"])
+
+			# two messages
+			self.assertEqual(len(call.args[0]), 2)
+
+			message_one = call.args[0][0]
+			message_two = call.args[0][1]
+			self.assertIsInstance(message_one, Message)
+			self.assertIsInstance(message_two, Message)
+			self.assertEqual(message_one.token, "abc")
+			self.assertEqual(message_two.token, "abc1")
+			self.assertEqual(message_one.android.collapse_key, "test_key")
+			self.assertEqual(message_two.android.collapse_key, "test_key")
 
 	def test_fcm_send_message_to_single_device_with_error(self):
 		# these errors are device specific, device.active will be set false
-		devices = ["abc", "abc1"]
+		devices = ["abc", "abc1", "abc2"]
 		self._create_fcm_devices(devices)
 
 		errors = [
-			responses.GCM_JSON_ERROR_NOTREGISTERED,
-			responses.GCM_JSON_ERROR_INVALIDREGISTRATION
+			messaging.UnregisteredError("error"),
+			messaging.SenderIdMismatchError("error"),
+			InvalidArgumentError("Invalid registration"),
 		]
+
 		for index, error in enumerate(errors):
+			return_value = BatchResponse(
+				[SendResponse(resp={"name": "..."}, exception=error)]
+			)
 			with mock.patch(
-				"push_notifications.gcm._fcm_send", return_value=error):
+				"firebase_admin.messaging.send_all", return_value=return_value
+			):
 				device = GCMDevice.objects.get(registration_id=devices[index])
 				device.send_message("Hello World!")
-				assert GCMDevice.objects.get(registration_id=devices[index]).active is False
+				self.assertFalse(GCMDevice.objects.get(registration_id=devices[index]).active)
 
 	def test_fcm_send_message_to_single_device_with_error_mismatch(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
 
+		return_value = BatchResponse(
+			[SendResponse(resp={"name": "..."}, exception=OSError())]
+		)
 		with mock.patch(
-			"push_notifications.gcm._fcm_send",
-			return_value=responses.GCM_JSON_ERROR_MISMATCHSENDERID
+			"firebase_admin.messaging.send_all",
+			return_value=return_value
 		):
-			# these errors are not device specific, GCMError should be thrown
-			with self.assertRaises(GCMError):
-				device.send_message("Hello World!")
-			assert GCMDevice.objects.get(registration_id="abc").active is True
+			# these errors are not device specific, device is not deactivated
+			response = device.send_message("Hello World!")
+			self.assertTrue(GCMDevice.objects.get(registration_id="abc").active)
+			self.assertEqual(response.failure_count, 1)
 
 	def test_fcm_send_message_to_multiple_devices_with_error(self):
-		self._create_fcm_devices(["abc", "abc1", "abc2"])
+		self._create_fcm_devices(["abc", "abc1", "abc2", "abc3"])
+
+		return_value = BatchResponse([
+			SendResponse(resp={"name": "..."}, exception=messaging.UnregisteredError("error")),
+			SendResponse(resp={"name": "..."}, exception=messaging.SenderIdMismatchError("error")),
+			SendResponse(resp={"name": "..."}, exception=OSError()),
+			SendResponse(resp={"name": "..."}, exception=InvalidArgumentError("Invalid registration")),
+		])
 		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON_MULTIPLE_ERROR
+			"firebase_admin.messaging.send_all", return_value=return_value
 		):
-			devices = GCMDevice.objects.all()
-			devices.send_message("Hello World")
-			assert not GCMDevice.objects.get(registration_id="abc").active
-			assert GCMDevice.objects.get(registration_id="abc1").active
-			assert not GCMDevice.objects.get(registration_id="abc2").active
+			GCMDevice.objects.all().send_message("Hello World")
+			self.assertFalse(GCMDevice.objects.get(registration_id="abc").active)
+			self.assertFalse(GCMDevice.objects.get(registration_id="abc1").active)
+			self.assertTrue(GCMDevice.objects.get(registration_id="abc2").active)
+			self.assertFalse(GCMDevice.objects.get(registration_id="abc3").active)
 
 	def test_fcm_send_message_to_multiple_devices_with_error_b(self):
-		self._create_fcm_devices(["abc", "abc1", "abc2"])
+		self._create_fcm_devices(["abc", "abc1", "abc2", "abc3"])
+
+		return_value = BatchResponse([
+			SendResponse(resp={"name": "..."}, exception=OSError()),
+			SendResponse(resp={"name": "..."}, exception=OSError()),
+			SendResponse(resp={"name": "..."}, exception=messaging.UnregisteredError("error")),
+			SendResponse(resp={"name": "..."}, exception=OSError()),
+		])
 
 		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON_MULTIPLE_ERROR_B
-		):
-			devices = GCMDevice.objects.all()
-			with self.assertRaises(GCMError):
-				devices.send_message("Hello World")
-			assert GCMDevice.objects.get(registration_id="abc").active is True
-			assert GCMDevice.objects.get(registration_id="abc1").active is True
-			assert GCMDevice.objects.get(registration_id="abc2").active is False
-
-	def test_fcm_send_message_to_multiple_devices_with_canonical_id(self):
-		self._create_fcm_devices(["foo", "bar"])
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON_MULTIPLE_CANONICAL_ID
+			"firebase_admin.messaging.send_all", return_value=return_value
 		):
 			GCMDevice.objects.all().send_message("Hello World")
-			assert not GCMDevice.objects.filter(registration_id="foo").exists()
-			assert GCMDevice.objects.filter(registration_id="bar").exists()
-			assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists() is True
-
-	def test_fcm_send_message_to_single_user_with_canonical_id(self):
-		old_registration_id = "foo"
-		self._create_fcm_devices([old_registration_id])
-
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=responses.GCM_JSON_CANONICAL_ID
-		):
-			GCMDevice.objects.get(registration_id=old_registration_id).send_message("Hello World")
-			assert not GCMDevice.objects.filter(registration_id=old_registration_id).exists()
-			assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists()
-
-	def test_fcm_send_message_to_same_devices_with_canonical_id(self):
-		first_device = GCMDevice.objects.create(
-			registration_id="foo", active=True, cloud_message_type="FCM"
-		)
-		second_device = GCMDevice.objects.create(
-			registration_id="bar", active=False, cloud_message_type="FCM"
-		)
-
-		with mock.patch(
-			"push_notifications.gcm._fcm_send",
-			return_value=responses.GCM_JSON_CANONICAL_ID_SAME_DEVICE
-		):
-			GCMDevice.objects.all().send_message("Hello World")
-
-		assert first_device.active is True
-		assert second_device.active is False
+			self.assertTrue(GCMDevice.objects.get(registration_id="abc").active)
+			self.assertTrue(GCMDevice.objects.get(registration_id="abc1").active)
+			self.assertFalse(GCMDevice.objects.get(registration_id="abc2").active)
+			self.assertTrue(GCMDevice.objects.get(registration_id="abc3").active)
 
 	def test_fcm_send_message_with_no_reg_ids(self):
 		self._create_fcm_devices(["abc", "abc1"])
 
-		with mock.patch("push_notifications.gcm._cm_send_request", return_value="") as p:
+		with mock.patch(
+			"firebase_admin.messaging.send_all",
+			return_value=responses.FCM_SUCCESS_MULTIPLE
+		) as p:
 			GCMDevice.objects.filter(registration_id="xyz").send_message("Hello World")
 			p.assert_not_called()
 
-		with mock.patch("push_notifications.gcm._cm_send_request", return_value="") as p:
+		with mock.patch(
+			"firebase_admin.messaging.send_all",
+			return_value=responses.FCM_SUCCESS_MULTIPLE
+		) as p:
 			reg_ids = [obj.registration_id for obj in GCMDevice.objects.all()]
-			send_bulk_message(reg_ids, {"message": "Hello World"}, "FCM")
-			p.assert_called_once_with(
-				["abc", "abc1"], {"message": "Hello World"}, cloud_type="FCM",
-				application_id=None
-			)
+			message = dict_to_fcm_message({"message": "Hello World"})
+			send_bulk_message(reg_ids, message)
+			p.assert_called_once()
 
 	def test_can_save_wsn_device(self):
 		device = GCMDevice.objects.create(registration_id="a valid registration id")

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ deps =
     pytest-django
     pywebpush
     djangorestframework
+    firebase-admin>=5,<6
     dj22: Django>=2.2,<3.0
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.0.5


### PR DESCRIPTION
Use new FCM v1 API by using firebase_admin SDK.

- Removed GCM type
- Added firebase-admin
- Updated documentation
- Updated tests
